### PR TITLE
Fix mesh subdivision index format selection

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 public static class MeshMulti
 {
@@ -197,7 +198,10 @@ public static class MeshMulti
         }
 
         Mesh newMesh = new Mesh();
-        newMesh.indexFormat = mesh.indexFormat;
+        if (newVertices.Count > 65535)
+            newMesh.indexFormat = IndexFormat.UInt32;
+        else
+            newMesh.indexFormat = mesh.indexFormat;
         newMesh.subMeshCount = subMeshCount;
         newMesh.vertices = newVertices.ToArray();
         if (uvSets[0].Length > 0) newMesh.uv = newUVs[0].ToArray();


### PR DESCRIPTION
## Summary
- Switch subdivision script to automatically choose 32-bit indices when vertex count exceeds UInt16 limit
- Import UnityEngine.Rendering namespace for IndexFormat enum

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd45d2148c8329bef621ceec3705d7