### PR TITLE
Fix smoothing parameter causing gaps in subdivided meshes

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -28,7 +28,7 @@ public static class MeshMulti
 
             var newMesh = SubdivideMesh(originalMesh);
             if (smooth)
-                ThinPlateSmooth(newMesh, smoothIterations, i, total);
+                ThinPlateSmooth(newMesh, smoothIterations, 0.1f, i, total);
 
             float percent = ((float)(i + 1) / total) * 100f;
             percent = Mathf.Floor(percent * 1000f) / 1000f;


### PR DESCRIPTION
## Summary
- pass correct smoothing factor to ThinPlateSmooth instead of mesh index

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd716b9e8083299c0a735177707480