### PR TITLE
Sanitize smoothed vertices to prevent crash

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -163,6 +163,18 @@ public static class MeshMulti
             }
         }
 
+        // Sanitize the smoothed vertices to avoid invalid values that can crash Unity.
+        for (int i = 0; i < vertices.Length; i++)
+        {
+            var v = vertices[i];
+            if (float.IsNaN(v.x) || float.IsNaN(v.y) || float.IsNaN(v.z) ||
+                float.IsInfinity(v.x) || float.IsInfinity(v.y) || float.IsInfinity(v.z))
+            {
+                v = Vector3.zero;
+                vertices[i] = v;
+            }
+        }
+
         mesh.vertices = vertices;
         mesh.RecalculateBounds();
         mesh.RecalculateNormals();


### PR DESCRIPTION
## Summary
- ensure smoothed meshes have finite vertices before recalculating bounds

## Testing
- `csc Editor/MeshMulti.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd74a0f0f48329999c83db2691054e