### PR TITLE
Fix smoothing algorithm sign to prevent mesh explosion

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -150,8 +150,10 @@ public static class MeshMulti
                 foreach (var n in adjacency[i]) sum += lap[n];
                 lap2[i] = sum / adjacency[i].Count - lap[i];
             }
+            // Subtracting moves vertices toward lower curvature. Using addition here
+            // would amplify curvature and can explode the mesh during smoothing.
             for (int i = 0; i < vertices.Length; i++)
-                vertices[i] += lambda * lap2[i];
+                vertices[i] -= lambda * lap2[i];
 
             // Keep duplicate-position vertices welded together
             foreach (var group in positionGroups.Values)


### PR DESCRIPTION
## Summary
- prevent smoothing from exploding meshes by subtracting curvature in ThinPlateSmooth

## Testing
- `dotnet --version` *(command not found)*
- `mcs --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd793c82c08329bd2b6d286c8321c5