### PR TITLE
Adjust vertex prediction to respect bounds

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -109,15 +109,38 @@ public static class MeshMulti
         Debug.Log(string.Format("Subdivided {0} meshes under '{1}' ({2:F3}%).", targetRenderers.Count, selected.name, finalPercent));
     }
 
-    public static int PredictSubdividedVertexCount(Mesh mesh)
+    public static int PredictSubdividedVertexCount(Mesh mesh, bool[] vertexMask = null)
     {
         int[] triangles = mesh.triangles;
         var edges = new HashSet<Edge>();
+        bool useMask = vertexMask != null && vertexMask.Length == mesh.vertexCount;
+        bool anyMasked = false;
+        if (useMask)
+        {
+            for (int i = 0; i < vertexMask.Length; i++)
+            {
+                if (vertexMask[i])
+                {
+                    anyMasked = true;
+                    break;
+                }
+            }
+            if (!anyMasked)
+                return mesh.vertexCount;
+        }
+
         for (int i = 0; i < triangles.Length; i += 3)
         {
             int v0 = triangles[i];
             int v1 = triangles[i + 1];
             int v2 = triangles[i + 2];
+
+            if (useMask && anyMasked)
+            {
+                if (!vertexMask[v0] && !vertexMask[v1] && !vertexMask[v2])
+                    continue;
+            }
+
             edges.Add(new Edge(v0, v1));
             edges.Add(new Edge(v1, v2));
             edges.Add(new Edge(v2, v0));
@@ -1203,7 +1226,7 @@ public class MeshMultiWindow : EditorWindow
 
             bool inRange = !restrictToBounds || (boundsValid && hasVerticesInBounds);
             if (inRange) includedRenderers++;
-            int predictedVertices = MeshMulti.PredictSubdividedVertexCount(mesh);
+            int predictedVertices = MeshMulti.PredictSubdividedVertexCount(mesh, (restrictToBounds && boundsValid) ? mask : null);
             int predictedTriangles = MeshMulti.PredictSubdividedTriangleCount(mesh);
             string label = string.Format(
                 "Vertices: {0} → {1}, Triangles: {2} → {3}",


### PR DESCRIPTION
## Summary
- allow PredictSubdividedVertexCount to accept an optional mask and ignore triangles fully outside the selected bounds
- update the editor UI to pass the computed bounds mask so the vertex increase estimate reflects the active bounds restriction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf4ca88ea88329a8753713c0da40e1