### PR TITLE
Remove automatic mesh optimization after smoothing

### DIFF
--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -89,7 +89,6 @@ public static class MeshMulti
                     }
                 }
                 ThinPlateSmooth(newMesh, smoothIterations, 0.1f, i, total, smoothedVertices);
-                OptimizeMesh(newMesh, 1e-4f, 1e-6f);
             }
 
             float percent = ((float)(i + 1) / total) * 100f;


### PR DESCRIPTION
## Summary
- stop invoking OptimizeMesh immediately after smoothing subdivided meshes to avoid risky automated changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf508f865c832981c36ee67b0aabc5