### PR TITLE
Avoid recalculating normals when blendshapes exist

### DIFF
--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -220,10 +220,17 @@ public static class MeshPolygonReducer
             newMesh.SetTriangles(perSubmeshResults[subMesh], subMesh);
 
         newMesh.RecalculateBounds();
-        if (mesh.normals != null && mesh.normals.Length > 0)
-            newMesh.RecalculateNormals();
-        if (mesh.tangents != null && mesh.tangents.Length > 0)
-            newMesh.RecalculateTangents();
+
+        // Recalculating normals or tangents on a mesh that has blend shapes breaks the
+        // stored deltas for those shapes. The original normals/tangents are already
+        // copied by Instantiate, so only recalculate them when no blend shapes exist.
+        if (mesh.blendShapeCount == 0)
+        {
+            if (mesh.normals != null && mesh.normals.Length > 0)
+                newMesh.RecalculateNormals();
+            if (mesh.tangents != null && mesh.tangents.Length > 0)
+                newMesh.RecalculateTangents();
+        }
         return newMesh;
     }
 }


### PR DESCRIPTION
## Summary
- avoid recalculating normals and tangents for meshes with blend shapes during polygon reduction to prevent corrupting blend shape data
- leave recalculations enabled for meshes without blend shapes to maintain shading

## Testing
- not run (editor script change)


------
https://chatgpt.com/codex/tasks/task_e_68d1292df970832999be645b81074e81