### PR TITLE
Fix mesh saving for FBX-sourced meshes

### DIFF
--- a/Editor/MeshAssetUtility.cs
+++ b/Editor/MeshAssetUtility.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+public static class MeshAssetUtility
+{
+    public static bool TryCreateDerivedMeshAsset(Mesh mesh, Mesh originalMesh, string suffix, out string assetPath)
+    {
+        assetPath = null;
+        if (mesh == null || originalMesh == null)
+            return false;
+
+        string originalPath = AssetDatabase.GetAssetPath(originalMesh);
+        if (string.IsNullOrEmpty(originalPath))
+            return false;
+
+        string directory = Path.GetDirectoryName(originalPath);
+        if (string.IsNullOrEmpty(directory))
+            directory = "Assets";
+
+        string fileName = BuildFileName(originalMesh, originalPath, suffix);
+        string candidatePath = CombineAssetPath(directory, fileName);
+        candidatePath = AssetDatabase.GenerateUniqueAssetPath(candidatePath);
+
+        AssetDatabase.CreateAsset(mesh, candidatePath);
+        assetPath = candidatePath;
+        return true;
+    }
+
+    private static string CombineAssetPath(string directory, string fileName)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return fileName;
+
+        if (directory.EndsWith("/", StringComparison.Ordinal))
+            return directory + fileName;
+
+        return directory + "/" + fileName;
+    }
+
+    private static string BuildFileName(Mesh originalMesh, string originalPath, string suffix)
+    {
+        string baseName = Path.GetFileNameWithoutExtension(originalPath);
+        string extension = Path.GetExtension(originalPath);
+
+        if (!string.IsNullOrEmpty(extension) && extension.Equals(".fbx", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!string.IsNullOrEmpty(originalMesh.name))
+                baseName = originalMesh.name;
+        }
+
+        if (string.IsNullOrEmpty(baseName))
+            baseName = !string.IsNullOrEmpty(originalMesh.name) ? originalMesh.name : "Mesh";
+
+        baseName = SanitizeFileName(baseName);
+
+        string suffixPart = string.IsNullOrEmpty(suffix)
+            ? string.Empty
+            : (suffix.StartsWith("_", StringComparison.Ordinal) ? suffix : "_" + suffix);
+
+        return baseName + suffixPart + ".asset";
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return "Mesh";
+
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(name.Length);
+        foreach (char c in name)
+        {
+            bool invalid = false;
+            for (int i = 0; i < invalidChars.Length; i++)
+            {
+                if (c == invalidChars[i])
+                {
+                    invalid = true;
+                    break;
+                }
+            }
+
+            builder.Append(invalid ? '_' : c);
+        }
+
+        string sanitized = builder.ToString().Trim();
+        return string.IsNullOrEmpty(sanitized) ? "Mesh" : sanitized;
+    }
+}

--- a/Editor/MeshMulti.cs
+++ b/Editor/MeshMulti.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -96,13 +95,8 @@ public static class MeshMulti
             EditorUtility.DisplayProgressBar("Subdivide Meshes", $"Processed {i + 1}/{total}: {renderer.name} ({percent:F3}%)", (float)(i + 1) / total);
             newMesh.name = originalMesh.name + "_subdivided";
 
-            var meshPath = AssetDatabase.GetAssetPath(originalMesh);
-            if (!string.IsNullOrEmpty(meshPath))
+            if (MeshAssetUtility.TryCreateDerivedMeshAsset(newMesh, originalMesh, "subdivided", out var newPath))
             {
-                var directory = Path.GetDirectoryName(meshPath);
-                var name = Path.GetFileNameWithoutExtension(meshPath) + "_subdivided.asset";
-                var newPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(directory, name));
-                AssetDatabase.CreateAsset(newMesh, newPath);
                 AssetDatabase.SaveAssets();
                 renderer.sharedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(newPath);
             }

--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -95,13 +94,8 @@ public static class MeshPolygonReducer
             EditorUtility.DisplayProgressBar("Reduce Mesh Polygons", $"Processed {i + 1}/{total}: {renderer.name} ({percent:F3}%)", (float)(i + 1) / total);
             newMesh.name = originalMesh.name + "_reduced";
 
-            var meshPath = AssetDatabase.GetAssetPath(originalMesh);
-            if (!string.IsNullOrEmpty(meshPath))
+            if (MeshAssetUtility.TryCreateDerivedMeshAsset(newMesh, originalMesh, "reduced", out var newPath))
             {
-                var directory = Path.GetDirectoryName(meshPath);
-                var name = Path.GetFileNameWithoutExtension(meshPath) + "_reduced.asset";
-                var newPath = AssetDatabase.GenerateUniqueAssetPath(Path.Combine(directory, name));
-                AssetDatabase.CreateAsset(newMesh, newPath);
                 assetCreated = true;
                 renderer.sharedMesh = AssetDatabase.LoadAssetAtPath<Mesh>(newPath);
             }


### PR DESCRIPTION
## Summary
- add MeshAssetUtility to build safe asset paths for derived meshes
- use the utility when saving reduced or subdivided meshes so FBX-sourced meshes persist

## Testing
- not run (Unity editor tooling)

------
https://chatgpt.com/codex/tasks/task_e_68d14698955c8329b3d5188b5bd447b8