### PR TITLE
Allow collapsing triangles shared by an edge

### DIFF
--- a/Editor/ArapMeshSimplifier.cs
+++ b/Editor/ArapMeshSimplifier.cs
@@ -687,12 +687,21 @@ internal sealed class ArapMeshSimplifier
             var tri = triangles[triIndex];
             if (tri.Removed)
                 continue;
+
+            bool usesSource = tri.A == source || tri.B == source || tri.C == source;
+            bool usesTargetOriginal = tri.A == target || tri.B == target || tri.C == target;
+            bool collapsesTriangle = usesSource && usesTargetOriginal;
+
             int a = tri.A;
             int b = tri.B;
             int c = tri.C;
             if (a == source) a = target;
             if (b == source) b = target;
             if (c == source) c = target;
+
+            if (collapsesTriangle)
+                continue;
+
             if (a == b || b == c || c == a)
                 return false;
 


### PR DESCRIPTION
## Summary
- allow ARAP edge collapses to proceed when a triangle shared by the collapsing edge becomes degenerate
- skip topological validity checks for triangles that will be removed by the collapse so simplification can succeed

## Testing
- not run (Unity editor script)

------
https://chatgpt.com/codex/tasks/task_e_68d14d0e54508329ad845af762c5564d