### PR TITLE
Fix mesh reduction robustness issues

### DIFF
--- a/Editor/MeshAssetUtility.cs
+++ b/Editor/MeshAssetUtility.cs
@@ -24,7 +24,17 @@ public static class MeshAssetUtility
         string candidatePath = CombineAssetPath(directory, fileName);
         candidatePath = AssetDatabase.GenerateUniqueAssetPath(candidatePath);
 
-        AssetDatabase.CreateAsset(mesh, candidatePath);
+        try
+        {
+            AssetDatabase.CreateAsset(mesh, candidatePath);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Failed to create derived mesh asset at '{candidatePath}': {ex.Message}");
+            return false;
+        }
+
+        Undo.RegisterCreatedObjectUndo(mesh, "Create Derived Mesh Asset");
         assetPath = candidatePath;
         return true;
     }


### PR DESCRIPTION
## Summary
- compute bounds masks for skinned meshes using bone-transformed vertex positions to respect animation pose
- improve mesh reduction diagnostics and performance, and stabilize ARAP global solve with an automatic anchor
- ensure derived mesh assets are undoable and handle asset creation failures gracefully

## Testing
- no automated tests were run (Unity editor scripts)


------
https://chatgpt.com/codex/tasks/task_e_68d1cf5158a4832997c3fa7d368ed588