### PR TITLE
Fix bone weight compatibility and naming collisions

### DIFF
--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -476,6 +476,7 @@ public static class MeshPolygonReducer
         if (mesh == null)
             return false;
 
+#if UNITY_2020_2_OR_NEWER
         try
         {
             using (var meshDataArray = Mesh.AcquireReadOnlyMeshData(mesh))
@@ -551,6 +552,19 @@ public static class MeshPolygonReducer
             boneWeights = null;
             return false;
         }
+#else
+        var legacyWeights = mesh != null ? mesh.boneWeights : null;
+        if (legacyWeights == null || legacyWeights.Length == 0)
+        {
+            boneWeights = null;
+            return false;
+        }
+
+        var result = new BoneWeight[legacyWeights.Length];
+        Array.Copy(legacyWeights, result, legacyWeights.Length);
+        boneWeights = result;
+        return true;
+#endif
     }
 
     private static void NormalizeBoneWeight(ref BoneWeight weight)


### PR DESCRIPTION
## Summary
- guard MeshData bone weight accessors behind UNITY_2020_2_OR_NEWER to keep compatibility with older Unity versions and fall back to legacy mesh.boneWeights when unavailable
- resolve local variable shadowing when copying blend shapes by renaming inner loop weights
- ensure blend shape frames use the retrieved frame weight value when adding to the mesh

## Testing
- not run (editor scripts)

------
https://chatgpt.com/codex/tasks/task_e_68d1e46b64b08329ab23445a867141fa