### PR TITLE
Fix editor mesh reducer compilation issues

### DIFF
--- a/Editor/ArapMeshSimplifier.cs
+++ b/Editor/ArapMeshSimplifier.cs
@@ -1849,14 +1849,14 @@ internal sealed class ArapMeshSimplifier
         }
     }
 
-    private static void AddBoneWeight(Dictionary<int, float> dict, int boneIndex, float weight)
+    private static void AddBoneWeight(Dictionary<int, float> dict, int boneIndex, float weightValue)
     {
-        if (weight <= 0f)
+        if (weightValue <= 0f)
             return;
         if (dict.TryGetValue(boneIndex, out float value))
-            dict[boneIndex] = value + weight;
+            dict[boneIndex] = value + weightValue;
         else
-            dict.Add(boneIndex, weight);
+            dict.Add(boneIndex, weightValue);
     }
 
     private static BoneWeight BuildBoneWeight(Dictionary<int, float> weights)
@@ -1984,8 +1984,8 @@ internal sealed class ArapMeshSimplifier
             return Array.Empty<BoneWeight>();
 
         var result = new BoneWeight[vertexCount];
-        var bonesPerVertex = meshData.GetBonesPerVertex();
-        var allWeights = meshData.GetAllBoneWeights();
+        var bonesPerVertex = mesh.GetBonesPerVertex();
+        var allWeights = mesh.GetAllBoneWeights();
         try
         {
             if (!bonesPerVertex.IsCreated || !allWeights.IsCreated || bonesPerVertex.Length == 0)

--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -328,7 +328,7 @@ public static class MeshPolygonReducer
         return mask;
     }
 
-    private static bool[] CalculateVerticesInsideBounds(SkinnedMeshRenderer renderer, Mesh mesh, Bounds bounds)
+    internal static bool[] CalculateVerticesInsideBounds(SkinnedMeshRenderer renderer, Mesh mesh, Bounds bounds)
     {
         if (mesh == null)
             return Array.Empty<bool>();
@@ -491,8 +491,8 @@ public static class MeshPolygonReducer
 
                 int vertexCount = meshData.vertexCount;
                 var result = new BoneWeight[vertexCount];
-                var bonesPerVertex = meshData.GetBonesPerVertex();
-                var allWeights = meshData.GetAllBoneWeights();
+                var bonesPerVertex = mesh.GetBonesPerVertex();
+                var allWeights = mesh.GetAllBoneWeights();
 
                 try
                 {
@@ -579,7 +579,7 @@ public static class MeshPolygonReducer
         weight.weight3 *= inv;
     }
 
-    private static int CountTotalTriangles(Mesh mesh)
+    internal static int CountTotalTriangles(Mesh mesh)
     {
         if (mesh == null)
             return 0;


### PR DESCRIPTION
## Summary
- expose mesh utility helpers so the editor window can reuse them
- update bone weight extraction to use Mesh APIs compatible with older Unity versions
- resolve naming conflict in the ARAP simplifier helper

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d1e54bc2e08329947f25463a6155ea