### PR TITLE
Fix CalculateVerticesInsideBounds reference

### DIFF
--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -737,7 +737,7 @@ public class MeshPolygonReducerWindow : EditorWindow
             bool[] mask = null;
             if (restrictToBounds && boundsValid)
             {
-                mask = CalculateVerticesInsideBounds(renderer, mesh, activeBounds);
+                mask = MeshPolygonReducer.CalculateVerticesInsideBounds(renderer, mesh, activeBounds);
                 for (int v = 0; v < mask.Length; v++)
                 {
                     if (mask[v])


### PR DESCRIPTION
## Summary
- qualify the CalculateVerticesInsideBounds call in MeshPolygonReducerWindow to reference the static helper on MeshPolygonReducer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e6905550832982eabe9ddf571ad4