### PR TITLE
Fix simplifier robustness and support non-triangle meshes

### DIFF
--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -602,13 +602,18 @@ public static class MeshPolygonReducer
                 else
                     topology = MeshTopology.Triangles;
 
-                if (topology != MeshTopology.Triangles)
-                    continue;
-
                 if (i < meshData.subMeshCount)
                 {
                     var descriptor = meshData.GetSubMesh(i);
-                    total += descriptor.indexCount / 3;
+                    switch (topology)
+                    {
+                        case MeshTopology.Triangles:
+                            total += descriptor.indexCount / 3;
+                            break;
+                        case MeshTopology.Quads:
+                            total += (descriptor.indexCount / 4) * 2;
+                            break;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- normalize triangle area checks and quadric generation to avoid prematurely discarding thin faces
- triangulate quad submeshes so the simplifier can operate on non-triangle meshes
- stabilize edge collapses and ARAP relaxation with merged rest positions, relaxed bone weight compatibility, and multi-point anchors
- count quad indices when estimating target triangle counts during reduction

## Testing
- not run (Unity editor project)


------
https://chatgpt.com/codex/tasks/task_e_68d1ea82dbac8329b5663b2b2e850c9c