### PR TITLE
Fix mesh simplifier issues

### DIFF
--- a/Editor/ArapMeshSimplifier.cs
+++ b/Editor/ArapMeshSimplifier.cs
@@ -1030,7 +1030,7 @@ internal sealed class ArapMeshSimplifier
             return false;
         if (va.Revision != candidate.RevisionA || vb.Revision != candidate.RevisionB)
             return false;
-        if (va.Locked && vb.Locked)
+        if (va.Locked || vb.Locked)
             return false;
         return true;
     }
@@ -1042,7 +1042,7 @@ internal sealed class ArapMeshSimplifier
         candidate = default;
         if (va == null || vb == null || va.Removed || vb.Removed)
             return false;
-        if (va.Locked && vb.Locked)
+        if (va.Locked || vb.Locked)
             return false;
 
         if (!AreBoneWeightsCompatible(va, vb))

--- a/Editor/MeshAssetUtility.cs
+++ b/Editor/MeshAssetUtility.cs
@@ -14,12 +14,13 @@ public static class MeshAssetUtility
             return false;
 
         string originalPath = AssetDatabase.GetAssetPath(originalMesh);
-        if (string.IsNullOrEmpty(originalPath))
-            return false;
-
-        string directory = Path.GetDirectoryName(originalPath);
-        if (string.IsNullOrEmpty(directory))
-            directory = "Assets";
+        string directory = null;
+        if (!string.IsNullOrEmpty(originalPath))
+        {
+            directory = Path.GetDirectoryName(originalPath);
+            if (string.IsNullOrEmpty(directory))
+                directory = "Assets";
+        }
 
         string fileName = BuildFileName(originalMesh, originalPath, suffix);
         var candidateDirectories = BuildCandidateDirectories(directory);
@@ -126,8 +127,14 @@ public static class MeshAssetUtility
 
     private static string BuildFileName(Mesh originalMesh, string originalPath, string suffix)
     {
-        string baseName = Path.GetFileNameWithoutExtension(originalPath);
-        string extension = Path.GetExtension(originalPath);
+        string baseName = null;
+        string extension = null;
+
+        if (!string.IsNullOrEmpty(originalPath))
+        {
+            baseName = Path.GetFileNameWithoutExtension(originalPath);
+            extension = Path.GetExtension(originalPath);
+        }
 
         if (!string.IsNullOrEmpty(extension) && extension.Equals(".fbx", StringComparison.OrdinalIgnoreCase))
         {


### PR DESCRIPTION
## Summary
- count triangle strip and fan topologies when computing mesh triangle totals
- use current skinned pose for bounds masks, include inactive renderers, and avoid collapsing locked vertices
- allow creating reduced mesh assets even when the source mesh has no asset path

## Testing
- not run (editor scripts only)

------
https://chatgpt.com/codex/tasks/task_e_68d1facc87148329b42750faa4837377