### PR TITLE
Fix mesh simplifier issues

### DIFF
--- a/Editor/ArapMeshSimplifier.cs
+++ b/Editor/ArapMeshSimplifier.cs
@@ -716,6 +716,12 @@ internal sealed class ArapMeshSimplifier
         return new Result { Mesh = mesh, RemovedTriangles = removedTriangles };
     }
 
+    public int GetCandidateVertexCount()
+    {
+        EnsureBaseData();
+        return baseCandidateVertexCount;
+    }
+
     private void EnsureBaseData()
     {
         if (baseInitialized)


### PR DESCRIPTION
## Summary
- ensure bounds-limited reduction builds vertex masks correctly
- expose ARAP simplifier candidate count so reducers can respect topology locks
- allow partial simplification results outside the 5% tolerance to be kept as a fallback

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d24437baf88329b7fa9e284b6f098b