### PR TITLE
Fix topology conversion and reduction targets

### DIFF
--- a/Editor/MeshPolygonReducer.cs
+++ b/Editor/MeshPolygonReducer.cs
@@ -253,11 +253,11 @@ public static class MeshPolygonReducer
             return null;
         }
 
-        float targetTriangleFloat = Mathf.Max(1f, originalTriangles * (1f - reductionRatio));
-        int targetTriangles = Mathf.Max(1, Mathf.RoundToInt(targetTriangleFloat));
-        int lowerTriangleBound = Mathf.Max(1, Mathf.RoundToInt(targetTriangleFloat * 0.95f));
+        float targetTriangleFloat = Mathf.Max(0f, originalTriangles * (1f - reductionRatio));
+        int targetTriangles = Mathf.Clamp(Mathf.RoundToInt(targetTriangleFloat), 0, originalTriangles);
+        int lowerTriangleBound = Mathf.Clamp(Mathf.RoundToInt(targetTriangleFloat * 0.95f), 0, originalTriangles);
         int upperTriangleBound = Mathf.Max(lowerTriangleBound, Mathf.RoundToInt(targetTriangleFloat * 1.05f));
-        upperTriangleBound = Mathf.Min(upperTriangleBound, originalTriangles);
+        upperTriangleBound = Mathf.Clamp(upperTriangleBound, lowerTriangleBound, originalTriangles);
 
         var simplifier = new ArapMeshSimplifier(mesh, effectiveMask, seed);
         int actualCandidateVertices = simplifier.GetCandidateVertexCount();


### PR DESCRIPTION
## Summary
- skip degenerate triangles when converting strips/fans/quads to triangles
- mark removed primitives in line and point submeshes so simplification results persist
- allow 100% reduction requests by permitting zero triangle targets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d28cb0e5d08329840351c1ca4960f9